### PR TITLE
kas: switch git from ssh to https

### DIFF
--- a/meta-avocado-example/conf/kas/peridio.yml
+++ b/meta-avocado-example/conf/kas/peridio.yml
@@ -7,14 +7,14 @@ header:
 repos:
 
   meta-erlang:
-    url: git@github.com:meta-erlang/meta-erlang
+    url: https://github.com/meta-erlang/meta-erlang
     commit: 8959b17e0d28bb685471f024120e7ab6c03d9a6d
     branch: kirkstone
     layers:
       .:
 
   meta-peridio:
-    url: git@github.com:peridio/meta-peridio
+    url: https://github.com/peridio/meta-peridio
     commit: 5b97f116bdadc406f5bdf235682085d1db06276c
     branch: kirkstone
     layers:

--- a/meta-avocado-meson/conf/kas/bsp/meson.yml
+++ b/meta-avocado-meson/conf/kas/bsp/meson.yml
@@ -3,7 +3,7 @@ header:
 
 repos:
   meta-meson:
-    url: git@github.com:superna9999/meta-meson
+    url: https://github.com/superna9999/meta-meson
     commit: 4a83d41dda9fcad026253046b677a1c20582391e
     branch: kirkstone
     layers:

--- a/meta-avocado-nvidia/conf/kas/bsp/nvidia.yml
+++ b/meta-avocado-nvidia/conf/kas/bsp/nvidia.yml
@@ -3,13 +3,13 @@ header:
 
 repos:
   meta-tegra:
-    url: git@github.com:oe4t/meta-tegra
+    url: https://github.com/oe4t/meta-tegra
     commit: 644aa6081f0be59e7644eede1833f358c3095872
     branch: kirkstone
     layers:
       .:
   meta-tegra-community:
-    url: git@github.com:oe4t/meta-tegra-community
+    url: htps://github.com/oe4t/meta-tegra-community
     commit: 4d864674754659d16a1865de5a345b3f9197f12b
     branch: kirkstone
     layers:

--- a/meta-avocado-nxp/conf/kas/bsp/nxp.yml
+++ b/meta-avocado-nxp/conf/kas/bsp/nxp.yml
@@ -3,7 +3,7 @@ header:
 
 repos:
   meta-imx:
-    url: git@github.com:nxp-imx/meta-imx
+    url: https://github.com/nxp-imx/meta-imx
     commit: ca68ab5d25322b51f54564275c84ab8de3c74ea6
     branch: kirkstone-5.15.71-2.2.2
     layers:
@@ -13,21 +13,21 @@ repos:
       meta-v2x:
 
   meta-freescale:
-    url: git@github.com:Freescale/meta-freescale
+    url: https://github.com/Freescale/meta-freescale
     commit: 710e55d529c86d15a93c4421365ef62eb601a49b
     branch: kirkstone
     layers:
       .:
 
   meta-freescale-3rdparty:
-    url: git@github.com:Freescale/meta-freescale-3rdparty
+    url: https://github.com/Freescale/meta-freescale-3rdparty
     commit: 9e94b64bdfebcf7bfdf2af6447cec866a4efa814
     branch: kirkstone
     layers:
       .:
 
   meta-freescale-distro:
-    url: git@github.com:Freescale/meta-freescale-distro
+    url: https://github.com/Freescale/meta-freescale-distro
     commit: d5bbb487b2816dfc74984a78b67f7361ce404253
     branch: kirkstone
     layers:


### PR DESCRIPTION
Switch kas to use git over https instead of ssh, this prevents issues with github presenting permission issues when trying to pull down public repositories.