### PR TITLE
Replace slash for colon in meta-advocado clone address

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ machine.
 ```bash
 mkdir build-qemuarm64-secureboot
 cd build-qemuarm64-secureboot
-git clone git@github.com/peridio/meta-avocado
+git clone git@github.com:peridio/meta-avocado
 ```
 
 ## Build


### PR DESCRIPTION
## Description 

* Today I built an ISO in an EC2 instance following this readme. When I was trying to build with kas I've got a repository not found error.  